### PR TITLE
Set default log level to LOG_ERROR

### DIFF
--- a/TradeUtil.mqh
+++ b/TradeUtil.mqh
@@ -95,7 +95,13 @@ void placeSellOrder(CTrade &m_trade, double sl, double tp, double lot, string sy
 }
 
 void printHelper(int level, string formattedText) {
-   int logLevel = GlobalVariableGet("LOG_LEVEL");
+
+   // Set default log level to show errors
+   int logLevel = LOG_ERROR;
+   if (GlobalVariableCheck("LOG_LEVEL")) {
+      logLevel = (int)GlobalVariableGet("LOG_LEVEL");
+   }
+
    if(level <= logLevel) {
       Print(formattedText);
    }


### PR DESCRIPTION
It might be good practice to show error messages by default if no log level exists.