### PR TITLE
Update .gitignore to ignore compiler log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 
 # Compiled log files
 *.log
+
+# VS code editor settings
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 *.out
 *.app
 *.ex5
+
+# Compiled log files
+*.log


### PR DESCRIPTION
Just a small fix to ignore compiler log files when checking in updates.

My build process outputs the compiler log files to the same directory as the source files.

