### PR TITLE
Add error message box for missing provider account number

### DIFF
--- a/Sharing-Is-Caring.mq5
+++ b/Sharing-Is-Caring.mq5
@@ -123,7 +123,9 @@ PositionData recPositions[];
 int OnInit() {
    //Input validations   
    if(RECEIVER == COPY_MODE && PROVIDER_ACCOUNT < 1000) {
-      printHelper(LOG_ERROR, "Provider Account is required and should be at least 4 digits long.");
+      string errorMsg = "Provider Account is required and should be at least 4 digits long.";
+      MessageBox(errorMsg, "Error: Provider Account Missing", MB_OK | MB_ICONERROR);
+      printHelper(LOG_ERROR, errorMsg);
       return(INIT_PARAMETERS_INCORRECT);
    }
    


### PR DESCRIPTION
This fix will show an error message box to show the user when they haven't given the correct provider account information.

![provider-account-error](https://github.com/wait4signal/sharing-is-caring/assets/43404319/a84cc256-26a9-4df5-b5bc-8b325f097777)
